### PR TITLE
DOC-5003: Add examples for creating new API Credentials

### DIFF
--- a/examples/example_api_credential_organization_admin.py
+++ b/examples/example_api_credential_organization_admin.py
@@ -1,0 +1,78 @@
+"""
+Create a Cribl.Cloud API Credential Example (Organization Admin)
+
+This example demonstrates how to create a new API Credential with the Admin Role on
+an Organization. The Admin Role is effective across the Organization, including
+all Workspaces and all products (no Workspace or product matrix is required).
+
+1. Create an SDK client with OAuth2 client credentials using the client_oauth security scheme.
+2. Create a new API Credential with Organization-level Admin and an optional IP allowlist 
+   to restrict API access for the API Credential to the specified IPv4 CIDR range.
+
+Use the returned client_id and client_secret for the new API Credential in subsequent
+requests. The client_secret is only returned on create.
+
+Prerequisites: Replace the placeholder values for ORG_ID, CLIENT_ID, and CLIENT_SECRET with
+your Organization ID and the Client ID and Secret for an existing API Credential. You need
+these values for an existing API Credential to authenticate this script.
+
+To get the Client ID and Secret for an existing API Credential, follow the steps at
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
+Your Client ID and Secret are sensitive information and should be kept private.
+
+NOTE: This example is for Cribl.Cloud only.
+"""
+
+from cribl_mgmt_plane import CriblMgmtPlane, models
+
+# Cribl.Cloud configuration: Replace the placeholder values
+CLIENT_ID = "your-client-id"  # Replace with the OAuth2 Client ID for an existing API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the OAuth2 Client Secret for an existing API Credential
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+
+# Token URL and audience for Cribl.Cloud OAuth2
+TOKEN_URL = "https://login.cribl.cloud/oauth/token"
+AUDIENCE = "https://api.cribl.cloud"
+
+IP_ALLOWLIST = ["203.0.113.0/24"]  # Replace with your IPv4 CIDR range.
+
+
+def main():
+    # Create authenticated SDK client with OAuth2
+    with CriblMgmtPlane(
+        security=models.Security(
+            client_oauth=models.SchemeClientOauth(
+                client_id=CLIENT_ID,
+                client_secret=CLIENT_SECRET,
+                token_url=TOKEN_URL,
+                audience=AUDIENCE,
+            ),
+        ),
+    ) as cmp_client:
+        created = cmp_client.api_credentials.create(
+            organization_id=ORG_ID,
+            name="Auto-Manage-WorkspacesAuto-Manage-Workspaces",
+            description="Used for automated Workspace management",
+            enabled=True,
+            roles={"organization_role": models.OrganizationRole.ADMIN},
+            ip_allowlist=IP_ALLOWLIST,
+        )
+        # client_secret is returned only on create; store it securely (do not log it).
+        _ = created.client_secret
+        print(
+            "✅ Created API Credential "
+            f"name={created.name!r} client_id={created.client_id!r}"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        STATUS_CODE = getattr(error, "status_code", None)
+        if STATUS_CODE == 401:
+            print("⚠️ Authentication failed! Check your CLIENT_ID and CLIENT_SECRET.")
+        elif STATUS_CODE == 429:
+            print("⚠️ Uh oh, you've reached the rate limit! Try again in a few seconds.")
+        else:
+            print(f"❌ Something went wrong: {error}")

--- a/examples/example_api_credential_organization_admin.py
+++ b/examples/example_api_credential_organization_admin.py
@@ -49,7 +49,7 @@ def main():
             ),
         ),
     ) as cmp_client:
-        created = cmp_client.api_credentials.create(
+        response = cmp_client.api_credentials.create(
             organization_id=ORG_ID,
             name="Auto-Manage-WorkspacesAuto-Manage-Workspaces",
             description="Used for automated Workspace management",
@@ -57,12 +57,16 @@ def main():
             roles={"organization_role": models.OrganizationRole.ADMIN},
             ip_allowlist=IP_ALLOWLIST,
         )
-        # client_secret is returned only on create; store it securely (do not log it).
-        _ = created.client_secret
-        print(
-            "✅ Created API Credential "
-            f"name={created.name!r} client_id={created.client_id!r}"
-        )
+        if isinstance(response, models.APICredentialCreateResponseSchema):
+            created = response
+            # client_secret is returned only on create; store it securely (do not log it).
+            _ = created.client_secret
+            print(
+                "✅ Created API Credential "
+                f"name={created.name!r} client_id={created.client_id!r}"
+            )
+        else:
+            print(f"❌ API error: {response.message} (status {response.status_code})")
 
 
 if __name__ == "__main__":

--- a/examples/example_api_credential_organization_admin.py
+++ b/examples/example_api_credential_organization_admin.py
@@ -9,18 +9,22 @@ all Workspaces and all products (no Workspace or product matrix is required).
 2. Create a new API Credential with Organization-level Admin and an optional IP allowlist 
    to restrict API access for the API Credential to the specified IPv4 CIDR range.
 
-Use the returned client_id and client_secret for the new API Credential in subsequent
-requests. The client_secret is only returned on create.
-
 Prerequisites: Replace the placeholder values for ORG_ID, CLIENT_ID, and CLIENT_SECRET with
 your Organization ID and the Client ID and Secret for an existing API Credential. You need
 these values for an existing API Credential to authenticate this script.
 
 To get the Client ID and Secret for an existing API Credential, follow the steps at
 https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
-Your Client ID and Secret are sensitive information and should be kept private.
 
-NOTE: This example is for Cribl.Cloud only.
+To use the new API Credential for later SDK calls, you need its client_id and client_secret.
+When create succeeds, the object returned from api_credentials.create(...) includes client_id,
+client_secret, name, and the other APICredentialCreateResponseSchema fields. Read the new
+client_secret as response.client_secret on that same object. The API returns client_secret
+only in the create response (not in GET responses). Do not print or log the client_secret. 
+Pass the client_id and client_secret for the new API Credential into client_oauth when you 
+construct the CriblMgmtPlane client for later SDK calls.
+
+Client Secrets are sensitive information and should be kept private.
 """
 
 from cribl_mgmt_plane import CriblMgmtPlane, models
@@ -57,16 +61,10 @@ def main():
             roles={"organization_role": models.OrganizationRole.ADMIN},
             ip_allowlist=IP_ALLOWLIST,
         )
-        if isinstance(response, models.APICredentialCreateResponseSchema):
-            created = response
-            # client_secret is returned only on create; store it securely (do not log it).
-            _ = created.client_secret
-            print(
-                "✅ Created API Credential "
-                f"name={created.name!r} client_id={created.client_id!r}"
-            )
-        else:
-            print(f"❌ API error: {response.message} (status {response.status_code})")
+        print(
+            "✅ Created API Credential "
+            f"name={response.name!r} client_id={response.client_id!r}"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/example_api_credential_workspace_product_roles.py
+++ b/examples/example_api_credential_workspace_product_roles.py
@@ -48,8 +48,20 @@ ALL_CRIBL_PRODUCTS = (
 
 def main():
     main_workspace_editor_products = [
-        {"product": product, "role": models.Role.EDITOR} for product in ALL_CRIBL_PRODUCTS
+        models.ProductRoleSchema(product=product, role=models.Role.EDITOR)
+        for product in ALL_CRIBL_PRODUCTS
     ]
+
+    roles = models.APICredentialRolesSchema(
+        organization_role=models.OrganizationRole.USER,
+        workspaces=[
+            models.WorkspaceRoleSchema(
+                workspace_id="main",
+                workspace_role=models.WorkspaceRole.USER,
+                products=main_workspace_editor_products,
+            ),
+        ],
+    )
 
     # Create authenticated SDK client with OAuth2
     with CriblMgmtPlane(
@@ -62,29 +74,24 @@ def main():
             ),
         ),
     ) as cmp_client:
-        created = cmp_client.api_credentials.create(
+        response = cmp_client.api_credentials.create(
             organization_id=ORG_ID,
             name="Product-Editor",
             description="Editor Role on all Cribl Products",
             enabled=True,
-            roles={
-                "organization_role": models.OrganizationRole.USER,
-                "workspaces": [
-                    {
-                        "workspace_id": "main",
-                        "workspace_role": models.WorkspaceRole.USER,
-                        "products": main_workspace_editor_products,
-                    },
-                ],
-            },
+            roles=roles,
             ip_allowlist=IP_ALLOWLIST,
         )
-        # client_secret is returned only on create; store it securely (do not log it).
-        _ = created.client_secret
-        print(
-            "✅ Created API Credential "
-            f"name={created.name!r} client_id={created.client_id!r}"
-        )
+        if isinstance(response, models.APICredentialCreateResponseSchema):
+            created = response
+            # client_secret is returned only on create; store it securely (do not log it).
+            _ = created.client_secret
+            print(
+                "✅ Created API Credential "
+                f"name={created.name!r} client_id={created.client_id!r}"
+            )
+        else:
+            print(f"❌ API error: {response.message} (status {response.status_code})")
 
 
 if __name__ == "__main__":

--- a/examples/example_api_credential_workspace_product_roles.py
+++ b/examples/example_api_credential_workspace_product_roles.py
@@ -1,0 +1,100 @@
+"""
+Create a Cribl.Cloud API Credential Example (Organization and Workspace User, Product Editor)
+
+This example demonstrates how to create a new API Credential with the User Role on
+an Organization and a Workspace, and the Editor Role on all Products.
+
+1. Create an SDK client with OAuth2 client credentials using the client_oauth security scheme.
+2. Create a new API Credential with:
+   - User Role on the Organization and the `main` Workspace.
+   - Editor on all Cribl products in the `main` Workspace.
+   - An optional IP allowlist to restrict API access for the API Credential to the specified IPv4 CIDR range.
+
+Use the returned client_id and client_secret for the new API Credential in subsequent
+requests. The client_secret is only returned on create.
+
+Prerequisites: Replace the placeholder values for ORG_ID, CLIENT_ID, and CLIENT_SECRET with
+your Organization ID and the Client ID and Secret for an existing API Credential. You need
+these values for an existing API Credential to authenticate this script.
+
+To get the Client ID and Secret for an existing API Credential, follow the steps at
+https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
+Your Client ID and Secret are sensitive information and should be kept private.
+
+NOTE: This example is for Cribl.Cloud only.
+"""
+
+from cribl_mgmt_plane import CriblMgmtPlane, models
+
+# Cribl.Cloud configuration: Replace the placeholder values
+CLIENT_ID = "your-client-id"  # Replace with the OAuth2 Client ID for an existing API Credential
+CLIENT_SECRET = "your-client-secret"  # Replace with the OAuth2 Client Secret for an existing API Credential
+ORG_ID = "your-org-id"  # Replace with the Organization ID
+
+# Token URL and audience for Cribl.Cloud OAuth2
+TOKEN_URL = "https://login.cribl.cloud/oauth/token"
+AUDIENCE = "https://api.cribl.cloud"
+
+IP_ALLOWLIST = ["203.0.113.0/24"]  # Replace with your IPv4 CIDR range.
+
+# All product identifiers exposed by this SDK for workspace-scoped roles.
+ALL_CRIBL_PRODUCTS = (
+    models.Product.STREAM,
+    models.Product.SEARCH,
+    models.Product.LAKE,
+    models.Product.EDGE,
+)
+
+
+def main():
+    main_workspace_editor_products = [
+        {"product": product, "role": models.Role.EDITOR} for product in ALL_CRIBL_PRODUCTS
+    ]
+
+    # Create authenticated SDK client with OAuth2
+    with CriblMgmtPlane(
+        security=models.Security(
+            client_oauth=models.SchemeClientOauth(
+                client_id=CLIENT_ID,
+                client_secret=CLIENT_SECRET,
+                token_url=TOKEN_URL,
+                audience=AUDIENCE,
+            ),
+        ),
+    ) as cmp_client:
+        created = cmp_client.api_credentials.create(
+            organization_id=ORG_ID,
+            name="Product-Editor",
+            description="Editor Role on all Cribl Products",
+            enabled=True,
+            roles={
+                "organization_role": models.OrganizationRole.USER,
+                "workspaces": [
+                    {
+                        "workspace_id": "main",
+                        "workspace_role": models.WorkspaceRole.USER,
+                        "products": main_workspace_editor_products,
+                    },
+                ],
+            },
+            ip_allowlist=IP_ALLOWLIST,
+        )
+        # client_secret is returned only on create; store it securely (do not log it).
+        _ = created.client_secret
+        print(
+            "✅ Created API Credential "
+            f"name={created.name!r} client_id={created.client_id!r}"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        STATUS_CODE = getattr(error, "status_code", None)
+        if STATUS_CODE == 401:
+            print("⚠️ Authentication failed! Check your CLIENT_ID and CLIENT_SECRET.")
+        elif STATUS_CODE == 429:
+            print("⚠️ Uh oh, you've reached the rate limit! Try again in a few seconds.")
+        else:
+            print(f"❌ Something went wrong: {error}")

--- a/examples/example_api_credential_workspace_product_roles.py
+++ b/examples/example_api_credential_workspace_product_roles.py
@@ -19,9 +19,16 @@ these values for an existing API Credential to authenticate this script.
 
 To get the Client ID and Secret for an existing API Credential, follow the steps at
 https://docs.cribl.io/cribl-as-code/sdks-auth/#sdks-auth-cloud.
-Your Client ID and Secret are sensitive information and should be kept private.
 
-NOTE: This example is for Cribl.Cloud only.
+To use the new API Credential for later SDK calls, you need its client_id and client_secret.
+When create succeeds, the object returned from api_credentials.create(...) includes client_id,
+client_secret, name, and the other APICredentialCreateResponseSchema fields. Read the new
+client_secret as response.client_secret on that same object. The API returns client_secret
+only in the create response (not in GET responses). Do not print or log the client_secret. 
+Pass the client_id and client_secret for the new API Credential into client_oauth when you 
+construct the CriblMgmtPlane client for later SDK calls.
+
+Client Secrets are sensitive information and should be kept private.
 """
 
 from cribl_mgmt_plane import CriblMgmtPlane, models
@@ -82,16 +89,10 @@ def main():
             roles=roles,
             ip_allowlist=IP_ALLOWLIST,
         )
-        if isinstance(response, models.APICredentialCreateResponseSchema):
-            created = response
-            # client_secret is returned only on create; store it securely (do not log it).
-            _ = created.client_secret
-            print(
-                "✅ Created API Credential "
-                f"name={created.name!r} client_id={created.client_id!r}"
-            )
-        else:
-            print(f"❌ API error: {response.message} (status {response.status_code})")
+        print(
+            "✅ Created API Credential "
+            f"name={response.name!r} client_id={response.client_id!r}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds Cursor-created examples for creating new API Credentials.

These examples are needed for a new code example doc that demonstrates how to use the SDK to create new API Credentials (since previously users had to do it only in the Cribl UI).

https://taktak.atlassian.net/browse/DOC-5003

Replaces the earlier (closed) PR https://github.com/criblio/cribl_cloud_management_sdk_python/pull/103.